### PR TITLE
Enable dynamic scroll mode for page slider

### DIFF
--- a/js/app.min.js
+++ b/js/app.min.js
@@ -616,25 +616,26 @@ let pageSlider = new Swiper('.page', {
 	// Отключаем автоинициализацию
 	init: false,
 
-	// События
-	/**/
-	on: {
-		// Событие инициализации
-		init: function () {
-			menuSlider();
-			//setScrollType();
-			wrapper.classList.add('_loaded')
-		},
-		// Событие смены слайда
-		slideChange: function () {
-			menuSliderRemove();
-			menuLinks[pageSlider.realIndex].classList.add('_active');
-		},
-		//resize: function () {
-		//setScrollType();
-		//}
+        // События
+        /**/
+        on: {
+                // Событие инициализации
+                init: function () {
+                        menuSlider();
+                        setScrollType();
+                        wrapper.classList.add('_loaded');
+                },
+                // Событие смены слайда
+                slideChange: function () {
+                        menuSliderRemove();
+                        menuLinks[pageSlider.realIndex].classList.add('_active');
+                        setScrollType();
+                },
+                resize: function () {
+                        setScrollType();
+                }
 
-	},
+        },
 
 });
 


### PR DESCRIPTION
## Summary
- Invoke `setScrollType()` during page slider initialization, slide changes and window resize to adjust scrolling behaviour.
- Use `setScrollType` to toggle `pageSlider.params.freeMode` based on slide content height.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f1d38ee94832f8bbd0226a6f701d5