### PR TITLE
Enable scrolling for screen content block

### DIFF
--- a/css/style.min.css
+++ b/css/style.min.css
@@ -3371,7 +3371,8 @@ body:not(.lg-from-hash) .lg-outer.lg-start-zoom .lg-item.lg-complete .lg-object 
   position: relative;
   z-index: 2;
   width: 100%;
-  height: 100%;
+  max-height: 100vh;
+  overflow-y: auto;
   background: #00000056;
 }
 .screen__block {


### PR DESCRIPTION
## Summary
- allow `.screen__content` area to scroll vertically by switching from `height: 100%` to `max-height: 100vh`
- enable vertical overflow via `overflow-y: auto`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f248ee024832fbe4e6702000d02d4