### PR TITLE
feat: allow edge release for mousewheel

### DIFF
--- a/js/app.min.js
+++ b/js/app.min.js
@@ -571,6 +571,7 @@ let pageSlider = new Swiper('.page', {
                 // Чувствительность колеса мыши
                 sensitivity: 1,
                 forceToAxis: true,
+                releaseOnEdges: true,
                 // Класс объекта на котором
                 // будет срабатывать прокрутка мышью.
                 //eventsTarget: ".image-slider"


### PR DESCRIPTION
## Summary
- enable releaseOnEdges for mousewheel to avoid scroll lock at boundaries
- keep forceToAxis option to ensure vertical scrolling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f25ce5bb4832fae28a16914573b4e