### PR TITLE
Refine scroll mode detection

### DIFF
--- a/js/app.min.js
+++ b/js/app.min.js
@@ -667,22 +667,14 @@ function menuSliderRemove() {
 }
 
 function setScrollType() {
-	if (wrapper.classList.contains('_free')) {
-		wrapper.classList.remove('_free');
-		pageSlider.params.freeMode = false;
-	}
-	for (let index = 0; index < pageSlider.slides.length; index++) {
-		const pageSlide = pageSlider.slides[index];
-		const pageSlideContent = pageSlide.querySelector('.screen__content');
-		if (pageSlideContent) {
-			const pageSlideContentHeight = pageSlideContent.offsetHeight;
-			if (pageSlideContentHeight > window.innerHeight) {
-				wrapper.classList.add('_free');
-				pageSlider.params.freeMode = true;
-				break;
-			}
-		}
-	}
+        wrapper.classList.remove('_free');
+        pageSlider.params.freeMode = false;
+        const active = pageSlider.slides[pageSlider.activeIndex];
+        const content = active && active.querySelector('.screen__content');
+        if (content && content.offsetHeight > window.innerHeight) {
+                wrapper.classList.add('_free');
+                pageSlider.params.freeMode = true;
+        }
 }
 
 pageSlider.init();


### PR DESCRIPTION
## Summary
- Check only the active slide's content in `setScrollType` to toggle free mode.
- Keep `setScrollType` calls in `init`, `slideChange`, and `resize` handlers.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f25c9249c832f97ab3c915247496a